### PR TITLE
Add a "System" color theme option

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 IMPROVEMENTS (arguably features):
-- System theme integration
 - Key shortcuts for all menu options (numbered)
 - diamond resize bit odd with other layers.
 - joiner layer with arrow heads won't always show - zindex.

--- a/cascii.html
+++ b/cascii.html
@@ -177,7 +177,7 @@ limitations under the License.
     }
 
     class ThemeManager {
-      defaultTheme = localStorage.getItem("theme") || ThemeManager.getPreferredSystemTheme();
+      defaultTheme = localStorage.getItem("theme") || "systemTheme";
 
       themes = {
         darkTheme: new Theme({

--- a/cascii.html
+++ b/cascii.html
@@ -244,6 +244,11 @@ limitations under the License.
 
       setTheme(theme) {
         localStorage.setItem("theme", theme);
+
+        if (theme === "systemTheme") {
+          theme = ThemeManager.getPreferredSystemTheme();
+        }
+
         this.currentTheme = this.themes[theme];
       }
 

--- a/cascii.html
+++ b/cascii.html
@@ -238,6 +238,10 @@ limitations under the License.
         return this.currentTheme.config;
       }
 
+      static getPreferredSystemTheme() {
+        return matchMedia("(prefers-color-scheme: light)").matches ? "lightTheme" : "darkTheme";
+      }
+
       setTheme(theme) {
         localStorage.setItem("theme", theme);
         this.currentTheme = this.themes[theme];

--- a/cascii.html
+++ b/cascii.html
@@ -4510,23 +4510,30 @@ limitations under the License.
         new ButtonComponent({
           themeId: "darkTheme",
           selectByDefault: themeManager.defaultTheme == "darkTheme",
-          css_width: "33%",
+          css_width: "25%",
           value: "Dark",
           on_click: () => this.setTheme("darkTheme"),
         }),
         new ButtonComponent({
           themeId: "lightTheme",
           selectByDefault: themeManager.defaultTheme == "lightTheme",
-          css_width: "33%",
+          css_width: "25%",
           value: "Light",
           on_click: () => this.setTheme("lightTheme"),
         }),
         new ButtonComponent({
           themeId: "consoleTheme",
           selectByDefault: themeManager.defaultTheme == "consoleTheme",
-          css_width: "33%",
+          css_width: "25%",
           value: "Console",
           on_click: () => this.setTheme("consoleTheme"),
+        }),
+        new ButtonComponent({
+          themeId: "systemTheme",
+          selectByDefault: themeManager.defaultTheme == "systemTheme",
+          css_width: "25%",
+          value: "System",
+          on_click: () => this.setTheme("systemTheme"),
         }),
       ];
 

--- a/cascii.html
+++ b/cascii.html
@@ -177,7 +177,7 @@ limitations under the License.
     }
 
     class ThemeManager {
-      defaultTheme = localStorage.getItem("theme") || "darkTheme";
+      defaultTheme = localStorage.getItem("theme") || ThemeManager.getPreferredSystemTheme();
 
       themes = {
         darkTheme: new Theme({


### PR DESCRIPTION
This adds the option to configure the app's color theme to follow the preference set in the browser/system. I use a media query to set the theme to Light if that's the user's preference, otherwise falling back to Dark.

Along with the "System" setting, I've used the media query approach in the fallback for `ThemeManager.defaultTheme`. What this means is that when there's no theme preference set in local storage, the theme we show (and afterwards persist in local storage) is based on the user's preference for light/dark schemes.

I tried to keep the individual commits as atomic as possible for the changes to be revertable, so feel free to disagree with individual parts of this PR and/or to squash-merge this.

It would also be possible to switch the theme if the user preference changes in the middle of a session, using [the `change` event on the `matchMedia` result](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#events), although I have not implemented that in this PR.