### PR TITLE
Add diagonals for Unicode

### DIFF
--- a/cascii.html
+++ b/cascii.html
@@ -586,8 +586,10 @@ limitations under the License.
         "|": ["solid-thin", "solid-bold", "line", "vertical", "ascii"],
         "─": ["solid-thin", "line", "lateral", "unicode"],
         "│": ["solid-thin", "line", "vertical", "unicode"],
-        "\\": ["solid-thin", "solid-bold", "diag-back", "line", "unicode", "ascii"],
-        "/": ["solid-thin", "solid-bold", "diag-forward", "line", "unicode", "ascii"],
+        "\\": ["solid-thin", "solid-bold", "diag-back", "line",  "ascii"],
+        "/": ["solid-thin", "solid-bold", "diag-forward", "line",  "ascii"],
+        "⟍": ["solid-thin", "solid-bold", "diag-back", "line", "unicode"],
+        "⟋": ["solid-thin", "solid-bold", "diag-forward", "line", "unicode"],
 
         // Dashed lines
         "'": ["dashed", "line", "vertical", "ascii"],


### PR DESCRIPTION
This PR adds new diagonals for the user if they're using Unicode mode. 
If the user is using ASCII mode, the ASCII diagonals are used like before.

Tested and working on my end with Firefox, the characters were added to Unicode (6.1) in 2012, so support should be broad.

Character details:
- https://unicodeplus.com/U+27CD
- https://unicodeplus.com/U+27CB