### PR TITLE
Add rounded corner characters as an option for unicode

### DIFF
--- a/cascii.html
+++ b/cascii.html
@@ -584,8 +584,8 @@ limitations under the License.
         "━": ["solid-bold", "line", "lateral", "unicode"],
         "┃": ["solid-bold", "line", "vertical", "unicode"],
         "|": ["solid-thin", "solid-bold", "line", "vertical", "ascii"],
-        "─": ["solid-thin", "line", "lateral", "unicode"],
-        "│": ["solid-thin", "line", "vertical", "unicode"],
+        "─": ["solid-thin", "solid-rounded", "line", "lateral", "unicode"],
+        "│": ["solid-thin", "solid-rounded", "line", "vertical", "unicode"],
         "\\": ["solid-thin", "solid-bold", "diag-back", "line", "unicode", "ascii"],
         "/": ["solid-thin", "solid-bold", "diag-forward", "line", "unicode", "ascii"],
 
@@ -615,6 +615,11 @@ limitations under the License.
         "┐": ["corner", "dashed", "solid-thin", "top-right", "unicode"],
         "└": ["corner", "dashed", "solid-thin", "bottom-left", "unicode"],
         "┘": ["corner", "dashed", "solid-thin", "bottom-right", "unicode"],
+
+        "╭": ["corner", "solid-rounded","top-left", "unicode"],
+        "╮": ["corner", "solid-rounded","top-right", "unicode"],
+        "╰": ["corner", "solid-rounded","bottom-left", "unicode"],
+        "╯": ["corner", "solid-rounded","bottom-right", "unicode"],
 
         "·": ["diamond-corner", "solid-thin", "solid-bold", "vertical", "lateral", "unicode"],
 
@@ -4937,6 +4942,9 @@ limitations under the License.
         ),
         new MenuButtonLeftComponent("―", "Solid bold", [modeMaster.has, "selected", "line-based"], [], [], () =>
           layerManager.redrawLineBasedEvent("solid-bold")
+        ),
+        new MenuButtonLeftComponent("╮", "Solid rounded", [modeMaster.has, "selected", "line-based"], [], [], () =>
+          layerManager.redrawLineBasedEvent("solid-rounded")
         ),
       ];
 

--- a/cascii.html
+++ b/cascii.html
@@ -583,9 +583,10 @@ limitations under the License.
         // Solid lines
         "━": ["solid-bold", "line", "lateral", "unicode"],
         "┃": ["solid-bold", "line", "vertical", "unicode"],
-        "|": ["solid-thin", "solid-bold", "line", "vertical", "ascii"],
+        "|": ["solid-thin", "solid-rounded", "solid-bold", "line", "vertical", "ascii"],
         "─": ["solid-thin", "solid-rounded", "line", "lateral", "unicode"],
         "│": ["solid-thin", "solid-rounded", "line", "vertical", "unicode"],
+
         "\\": ["solid-thin", "solid-bold", "diag-back", "line",  "ascii"],
         "/": ["solid-thin", "solid-bold", "diag-forward", "line",  "ascii"],
         "⟍": ["solid-thin", "solid-bold", "diag-back", "line", "unicode"],
@@ -595,7 +596,7 @@ limitations under the License.
         "'": ["dashed", "line", "vertical", "ascii"],
         "╶": ["dashed", "line", "lateral", "unicode"],
         "╷": ["dashed", "line", "vertical", "unicode"],
-        "-": ["dashed", "solid-bold", "solid-thin", "line", "lateral", "ascii"],
+        "-": ["dashed", "solid-bold", "solid-thin", "solid-rounded", "line", "lateral", "ascii"],
 
         // Arrows
         "^": ["arrow", "up", "ascii"],
@@ -632,6 +633,7 @@ limitations under the License.
           "vertical",
           "solid-bold",
           "solid-thin",
+          "solid-rounded",
           "dashed",
           "ascii",
           "top-left",

--- a/cascii.html
+++ b/cascii.html
@@ -586,8 +586,10 @@ limitations under the License.
         "|": ["solid-thin", "solid-bold", "line", "vertical", "ascii"],
         "─": ["solid-thin", "line", "lateral", "unicode"],
         "│": ["solid-thin", "line", "vertical", "unicode"],
-        "\\": ["solid-thin", "solid-bold", "diag-back", "line", "unicode", "ascii"],
-        "/": ["solid-thin", "solid-bold", "diag-forward", "line", "unicode", "ascii"],
+        "\\": ["solid-thin", "solid-bold", "diag-back", "line",  "ascii"],
+        "/": ["solid-thin", "solid-bold", "diag-forward", "line",  "ascii"],
+        "⟍": ["solid-thin", "solid-bold", "diag-back", "line", "unicode"],
+        "⟋": ["solid-thin", "solid-bold", "diag-forward", "line", "unicode"],
 
         // Dashed lines
         "'": ["dashed", "line", "vertical", "ascii"],


### PR DESCRIPTION
This PR changes the Unicode characters to use the rounded-edge equivalents instead of the prior hard edges.

This is a subjective change so I'm opening it as a separate PR in case its preferred, otherwise feel free to close. It'd be preferable if e.g. the user could choose themselves, but that's not currently implemented.

The characters were added in Unicode 1.1 in 1993, so support should be close to universal: https://unicodeplus.com/U+256D

Edit: see comments